### PR TITLE
Static check workflow

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,38 @@
+---
+Checks:          'clang-diagnostic-*,clang-analyzer-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle:     none
+User:            lenty
+CheckOptions:
+  - key:             cert-dcl16-c.NewSuffixes
+    value:           'L;LL;LU;LLU'
+  - key:             cert-oop54-cpp.WarnOnlyIfThisHasSuspiciousField
+    value:           '0'
+  - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
+    value:           '1'
+  - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             google-readability-braces-around-statements.ShortStatementLines
+    value:           '1'
+  - key:             google-readability-function-size.StatementThreshold
+    value:           '800'
+  - key:             google-readability-namespace-comments.ShortNamespaceLines
+    value:           '10'
+  - key:             google-readability-namespace-comments.SpacesBeforeComments
+    value:           '2'
+  - key:             modernize-loop-convert.MaxCopySize
+    value:           '16'
+  - key:             modernize-loop-convert.MinConfidence
+    value:           reasonable
+  - key:             modernize-loop-convert.NamingStyle
+    value:           CamelCase
+  - key:             modernize-pass-by-value.IncludeStyle
+    value:           llvm
+  - key:             modernize-replace-auto-ptr.IncludeStyle
+    value:           llvm
+  - key:             modernize-use-nullptr.NullMacros
+    value:           'NULL'
+...
+

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -108,5 +108,5 @@ jobs:
       - name: clang-tidy
         shell: bash
         run: |
-          find . -name "*.cpp" | xargs clang-tidy -p build
+          find . -name "*.cpp" | xargs clang-tidy -p ${{runner.workspace}}/build
         

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -103,7 +103,7 @@ jobs:
       - name: cppcheck
         shell: bash
         run: |
-          cppcheck --profile=build/compile_commands.json -i${{runner.workspace}}/build/_deps
+          cppcheck --project=${{runner.workspace}}/build/compile_commands.json -i${{runner.workspace}}/build/_deps
 
       - name: clang-tidy
         shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,13 +13,11 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  CC: /usr/bin/clang
-  CXX: /usr/bin/clang++
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  build_and_test:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
@@ -33,7 +31,7 @@ jobs:
         shell: bash
         run: sudo apt install -y lcov
 
-      # Cmake Configure
+      # CMake informatiuon and setting up build dir
       - name: Create Build Environment
         run: cmake --version && cmake -E make_directory ${{runner.workspace}}/build
 
@@ -47,7 +45,7 @@ jobs:
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: 
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
           
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -70,29 +68,37 @@ jobs:
           lcov --no-external --remove coverage.info '/usr/*' '*/gtest*' --output-file coverage.info
           lcov --list coverage.info # debug info
           bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
-      - uses: actions/upload-artifact@v2
-        with:
-          name: build_dir
-          path: ./build
-
           
   static-check:
     # The type of runner that the job will run on
+    env:
+      CC: /usr/bin/clang
+      CXX: /usr/bin/clang++
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
 
-      - uses: actions/download-artifact@v2
-        with:
-          name: build_dir
-          path: ./build
-
       - name: Install Dependencies 
         shell: bash
         run: sudo apt install -y cppcheck clang clang-tidy 
+      
+      # Cmake Configure
+      - name: Create Build Environment
+        run: cmake --version && cmake -E make_directory ${{runner.workspace}}/build
+
+      # Use a bash shell so we can use the same syntax for environment variable
+      # access regardless of the host operating system.
+      # If no shell is not given, then the runner shell is used, which has no env var.
+      - name: Configure CMake
+        shell: bash
+        working-directory: ${{runner.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source 
+        # and build directories, but this is only available with CMake 3.13 and higher.  
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: 
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
         
       - name: cppcheck
         shell: bash

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,8 @@ on:
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
   BUILD_TYPE: Debug
-  CODECOV_TOKEN: 124cebc4-3b71-424b-9ad5-8d378ce97b5b
+  CC: /usr/bin/clang
+  CXX: /usr/bin/clang++
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -30,7 +31,7 @@ jobs:
       - name: Install Dependencies 
         working-directory: ${{runner.workspace}}
         shell: bash
-        run: sudo apt install -y cppcheck clang-tidy lcov
+        run: sudo apt install -y lcov
 
       # Cmake Configure
       - name: Create Build Environment
@@ -46,7 +47,7 @@ jobs:
         # and build directories, but this is only available with CMake 3.13 and higher.  
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: 
-          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+          cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           
       - name: Build
         working-directory: ${{runner.workspace}}/build
@@ -69,5 +70,37 @@ jobs:
           lcov --no-external --remove coverage.info '/usr/*' '*/gtest*' --output-file coverage.info
           lcov --list coverage.info # debug info
           bash <(curl -s https://codecov.io/bash) -f coverage.info || echo "Codecov did not collect coverage reports"
+      - uses: actions/upload-artifact@v2
+        with:
+          name: build_dir
+          path: ./build
 
+          
+  static-check:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v2
+        with:
+          name: build_dir
+          path: ./build
+
+      - name: Install Dependencies 
+        shell: bash
+        run: sudo apt install -y cppcheck clang clang-tidy 
+        
+      - name: cppcheck
+        shell: bash
+        run: |
+          cppcheck --profile=build/compile_commands.json -i${{runner.workspace}}/build/_deps
+
+      - name: clang-tidy
+        shell: bash
+        run: |
+          find . -name "*.cpp" | xargs clang-tidy -p build
         

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,17 +4,19 @@ enable_testing()
 set(CMAKE_CXX_STANDARD 17)
 
 # ######### [Cppcheck] ##########
-find_program(CMAKE_CXX_CPPCHECK NAMES cppcheck)
-if(CMAKE_CXX_CPPCHECK)
-  list(APPEND CMAKE_CXX_CPPCHECK "--enable=warning" "--inconclusive" "--force"
-       "--inline-suppr")
-else()
-  message(WARNING "Cppcheck not found, disable cppcheck function")
-  unset(CMAKE_CXX_CPPCHECK CACHE)
-endif()
+# find_program(CMAKE_CXX_CPPCHECK NAMES cppcheck)
+# if(CMAKE_CXX_CPPCHECK)
+#   message(STATUS "Cppcheck found and enabled!")
+#   list(APPEND CMAKE_CXX_CPPCHECK "--enable=warning" "--inconclusive" "--force"
+#        "--inline-suppr")
+# else()
+#   message(WARNING "Cppcheck not found, disable cppcheck function")
+#   unset(CMAKE_CXX_CPPCHECK CACHE)
+# endif()
 # ##############################################################################
 
-# ######### Clang-tidy ##########
+# Clang-tidy ########
+
 # set(CMAKE_CXX_CLANG_TIDY "clang-tidy;-checks=*")
 
 # ######### Code Coverage ##########

--- a/src/matrix_basic/matrix_on_heap.hpp
+++ b/src/matrix_basic/matrix_on_heap.hpp
@@ -9,9 +9,9 @@ class Matrix {
     std::vector<unsigned int> shp;
 
 public:
-    Matrix(std::initializer_list<T> lst): elems(lst), shp{lst.size()} {};
+    Matrix(std::initializer_list<T> lst): elems(lst), shp{static_cast<unsigned int>(lst.size())} {};
     // init all elements with given value
     Matrix(unsigned int N, T val): elems{std::vector<T>(N, val)}, shp{N} {};
-    std::vector<unsigned int> shape() { return shp; };
-    const std::vector<T>&     get_elems() { return elems; };
+    auto                  shape() const { return shp; };
+    const std::vector<T>& get_elems() { return elems; };
 };


### PR DESCRIPTION
### Fixed Problem
- Fix wrong coverage value

### Improvement
- Enable clang-tidy for static check  
- sperate cppcheck from original CMakeLists.txt